### PR TITLE
fix try-catch

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,7 @@
 name: Compilation & tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -1,6 +1,7 @@
 name: Code style check
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Currently exceptions were not being caught, which means that when an exception is raised the app crashes.
Such exceptions can be raised from the plugin side, more specifically, only from the
`handle_query_contract_ui()` which eventually can call `u64_to_string`, `amountToString`.